### PR TITLE
Jdbc logger

### DIFF
--- a/server-install/src/main/scripts/install/raspbian/install.sh
+++ b/server-install/src/main/scripts/install/raspbian/install.sh
@@ -74,7 +74,7 @@ mkdir $LOG_ROOT
 chown -R $NH_USER $LOG_ROOT
 
 # pid-file
-mkdir $PID_ROOT
+mkdir -p $PID_ROOT
 chown -R $NH_USER $PID_ROOT
 
 # Install daemon


### PR DESCRIPTION
Now possible to make the H2 Web Console public from the H2DatabaseTCPServer home item.
The settings are persisted so that web console and/or database server are activated (or not) on start up.
The local (or public IP) address to the Web console is shown.
Note, running on Raspberry Pi don't work switching _off_ Web Console from the NetHomeServer GUI. Instead you will have to access the H2 Web Console and then Preferences and switch off remote access to the Console from there (see: Only allow local connections). This is due to a limitation in how one can disable access to the console programmatically. So, in the meanwhile, please do it from the H2 console, if needed. From my Mac, this is not a problem... See also this: https://github.com/h2database/h2database/issues/238.

Also, fixed a minor bug related to creating the path on a RASPI.

Note, there is an outstanding issue with how the installation (and upgrade) is done on RASPI. The PID directory is not created correctly (or at all) and you can also see that restarting the server takes too long time (due to the PID, I guess). I will try to take a look at this later.

/Peter